### PR TITLE
Rpetrina/docker refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target
+reports
+logs
+.git
+.gauge
+.gitignore
+docker-compose.yml
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,13 @@ RUN	gauge install java --version 0.6.9 && \
     gauge install xml-report && \
     gauge install html-report
 ENV PATH=$HOME/.gauge:$PATH
+
+#Install Maven dependencies
+RUN sudo mkdir -p /project
+RUN sudo chown circleci /project
+USER circleci
+WORKDIR /project
+COPY pom.xml .
+RUN mvn -B -e -f pom.xml dependency:resolve-plugins dependency:resolve test-compile -DskipTests -Dmaven.test.skip=true -Dgaugeexecute=none
+COPY . .
+RUN mvn gauge:execute -DspecsDir=specs -Dgaugeexecute=none

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ $ docker-compose build --no-cache && docker-compose up -d
 * Note: On windows, use %cd% instead of $PWD
 
 ```bash
-$ docker run --link selenium-hub:hub -v $PWD:/project gaugejavaseleniumtest mvn gauge:execute -DspecsDir=specs
-docker run --link browsertestframework_hub_1 -it --net browsertestframework_default -v $PWD:/project gaugejavaseleniumtest /bin/bash -c "cd /project && mvn test-compile && mvn gauge:execute -DspecsDir=specs"
+$ docker run --link browsertestframework_hub_1 -it --net browsertestframework_default -v $PWD:/project gaugejavaseleniumtest /bin/bash -c "cd /project && mvn test-compile && mvn gauge:execute -DspecsDir=specs"
 ```
 
 ## Step 4: Kill the docker containers for each browser to clean up

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # browsertestframework-rpetrina
 
-## Step 1: Set up docker
+## Step 1: Clone this repository
+
+## Step 2: Set up docker
 
 * Install docker (or Docker For Windows)
 
-## Step 2: Set up the Selenium Docker images
+## Step 3: Set up the Selenium Docker images
 
 ```bash
 $ docker-compose rm -f
@@ -12,21 +14,24 @@ $ docker-compose pull
 $ docker-compose build --no-cache && docker-compose up -d
 ```
 
-## Step 3: Run the tests using the gaugejavaselenium container
+## Step 4: Run the tests using the gaugejavaselenium container
 
 * Note: On windows, use %cd% instead of $PWD
 
 ```bash
-$ docker run --link browsertestframework_hub_1 -it --net browsertestframework_default -v $PWD:/project gaugejavaseleniumtest /bin/bash -c "cd /project && mvn test-compile && mvn gauge:execute -DspecsDir=specs"
+$ docker run --link browsertestframework_hub -it --net browsertestframework_default -v $PWD:/project browsertestframework_javagaugeselenium /bin/bash -c "cd /project && mvn test-compile && mvn gauge:execute -DspecsDir=specs -Dgaugeexecute=test"
 ```
 
-## Step 4: Kill the docker containers for each browser to clean up
+## Step 5: Kill the docker containers for each browser to clean up
 
 ```bash
 $ docker-compose down
 ```
 
-* You can run the tests again by repeating Steps 2-4. Note that you can specify the user's information in the [FindRate.spec](specs/FindRate.spec) file. New user information is required to reproduce the new user sign up functionality.
+* You can run the tests again by repeating Steps 3-5.
+  * For repeated test runs, Step 3 can be simplified to "docker-compose build && docker-compose up -d".
   * It may not be necessary to run "mvn test-compile" for each test run.
+* Note: you can specify the user's information in the [FindRate.spec](specs/FindRate.spec) file.
+* You can specify the initial test URL and the browser under which to test in [user.properties](env/default/user.properties)
 * Test reports are available in the [reports](reports) directory.
   * You can view the results of the test by opening FindRate.html in a browser after running the test. This file can be found in the html-report/specs directory.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ docker-compose pull
 $ docker-compose build --no-cache && docker-compose up -d
 ```
 
+* This step may take some time to complete while docker creates the images needed.
+
 ## Step 4: Run the tests using the gaugejavaselenium container
 
 * Note: On windows, use %cd% instead of $PWD
@@ -35,3 +37,4 @@ $ docker-compose down
 * You can specify the initial test URL and the browser under which to test in [user.properties](env/default/user.properties)
 * Test reports are available in the [reports](reports) directory.
   * You can view the results of the test by opening FindRate.html in a browser after running the test. This file can be found in the html-report/specs directory.
+* You can watch the text execution when the browser images in [docker-compose.yml](docker-compose.yml) are using the debug versions, by connecting to localhost:5900 (Firefox) or 5901 (Chrome) with VNC. When prompted for a password, use 'secret'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker run --link browsertestframework_hub_1 -it --net browsertestframework_de
 $ docker-compose down
 ```
 
-* You can run the tests again by repeating Steps 3-5. Note that you can specify the user's information in the [FindRate.spec](specs/FindRate.spec) file. New user information is required to reproduce the new user sign up functionality.
+* You can run the tests again by repeating Steps 2-4. Note that you can specify the user's information in the [FindRate.spec](specs/FindRate.spec) file. New user information is required to reproduce the new user sign up functionality.
   * It may not be necessary to run "mvn test-compile" for each test run.
 * Test reports are available in the [reports](reports) directory.
   * You can view the results of the test by opening FindRate.html in a browser after running the test. This file can be found in the html-report/specs directory.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,27 @@
-# browsertestframework
+# browsertestframework-rpetrina
 
 ## Step 1: Set up docker
 
-* Install docker
-* Set up the Gauge-Selenium docker image
+* Install docker (or Docker For Windows)
+
+## Step 2: Set up the Selenium Docker images
 
 ```bash
-$ docker pull circleci/openjdk:8-jdk-browsers
-$ docker build --no-cache -t gaugejavaseleniumtest:latest .
+$ docker-compose rm -f
+$ docker-compose pull
+$ docker-compose up --build -d
 ```
 
-## Step 2: Build the tests using the gaugejavaselenium container
+## Step 3: Run the tests using the gaugejavaselenium container
 
-* Note: On windows, use "cd" instead of $PWD
-
-```bash
-$ docker run -v $PWD:/project gaugejavaseleniumtest /bin/bash -c "cd /project && mvn test-compile"
-```
-
-## Step 3: Set up the selenium Docker images
-
-```bash
-$ docker-compose up -d
-```
-
-## Step 4: Run the tests using the gaugejavaselenium container
+* Note: On windows, use %cd% instead of $PWD
 
 ```bash
 $ docker run --link selenium-hub:hub -v $PWD:/project gaugejavaseleniumtest mvn gauge:execute -DspecsDir=specs
 docker run --link browsertestframework_hub_1 -it --net browsertestframework_default -v $PWD:/project gaugejavaseleniumtest /bin/bash -c "cd /project && mvn test-compile && mvn gauge:execute -DspecsDir=specs"
 ```
 
-## Step 5: Kill the docker containers for each browser to clean up
+## Step 4: Kill the docker containers for each browser to clean up
 
 ```bash
 $ docker-compose down
@@ -39,4 +29,5 @@ $ docker-compose down
 
 * You can run the tests again by repeating Steps 3-5. Note that you can specify the user's information in the [FindRate.spec](specs/FindRate.spec) file. New user information is required to reproduce the new user sign up functionality.
   * It may not be necessary to run "mvn test-compile" for each test run.
-* Test reports are available in the reports directory.
+* Test reports are available in the [reports](reports) directory.
+  * You can view the results of the test by opening FindRate.html in a browser after running the test. This file can be found in the html-report/specs directory.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```bash
 $ docker-compose rm -f
 $ docker-compose pull
-$ docker-compose up --build -d
+$ docker-compose build --no-cache && docker-compose up -d
 ```
 
 ## Step 3: Run the tests using the gaugejavaselenium container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - hub
     environment:
       HUB_HOST: hub
+    ports:
+      - "5900:5900"
 
   chrome:
     image: selenium/node-chrome
@@ -23,6 +25,8 @@ services:
       - hub
     environment:
       HUB_HOST: hub
+    ports:
+      - "5901:5900"
 
   hub:
     container_name: browsertestframework_hub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
-  app:
+  javagaugeselenium:
     container_name: javagaugeselenium  
     build: .
   firefox:
@@ -25,6 +25,7 @@ services:
       HUB_HOST: hub
 
   hub:
+    container_name: browsertestframework_hub
     image: selenium/hub
     ports:
       - "4444:4444"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2'
 services:
+  app:
+    container_name: javagaugeselenium  
+    build: .
   firefox:
     image: selenium/node-firefox
     #image: selenium/node-firefox-debug

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,16 @@
             <version>25.1-jre</version>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <activation>
+                <property>
+                    <name>gaugeexecute</name>
+                    <value>test</value>
+                </property>
+            </activation>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -54,7 +64,7 @@
                 <version>1.3.0</version>
                 <executions>
                     <execution>
-                        <phase>test</phase>
+                        <phase>${gaugeexecute}</phase>
                         <configuration>
                             <specsDir>specs</specsDir>
                         </configuration>

--- a/src/test/java/GetRate.java
+++ b/src/test/java/GetRate.java
@@ -101,7 +101,7 @@ public class GetRate extends Base {
     public void validatetextandbuttonarepresent(String arg0) {
         WebDriverWait waitforconfirmationpage = new WebDriverWait(webDriver, 30);
         if (!existinguser) {
-            wait.until(ExpectedConditions.elementToBeClickable(map.continuebutton())).click();
+            waitforconfirmationpage.until(ExpectedConditions.elementToBeClickable(map.continuebutton())).click();
         }
 
         waitforconfirmationpage.until((ExpectedConditions.visibilityOf(map.welcomesection())));

--- a/src/test/java/utils/driver/DriverFactory.java
+++ b/src/test/java/utils/driver/DriverFactory.java
@@ -52,7 +52,9 @@ public class DriverFactory {
     @AfterSuite
     public void tearDown() {
         driver.close();
-        driver.quit();
+        if (!BROWSER.toUpperCase().equals("FIREFOX")) {
+            driver.quit();
+        }
     }
     
 }

--- a/src/test/java/utils/driver/DriverFactory.java
+++ b/src/test/java/utils/driver/DriverFactory.java
@@ -34,14 +34,14 @@ public class DriverFactory {
                 driver = new InternetExplorerDriver();
                 break;
             case "FIREFOX":
-                RemoteWebDriver firefox = new RemoteWebDriver(new URL("http://browsertestframework_hub_1:4444/wd/hub"), firefoxCapabilities);
+                RemoteWebDriver firefox = new RemoteWebDriver(new URL("http://browsertestframework_hub:4444/wd/hub"), firefoxCapabilities);
                 driver = firefox;
-                driver.get(URL);
+                //driver.get(URL);
                 break;
             default:
-                RemoteWebDriver chrome = new RemoteWebDriver(new URL("http://browsertestframework_hub_1:4444/wd/hub"), chromeCapabilities);
+                RemoteWebDriver chrome = new RemoteWebDriver(new URL("http://browsertestframework_hub:4444/wd/hub"), chromeCapabilities);
                 driver = chrome;
-                driver.get(URL);
+                //driver.get(URL);
             }
 
         } catch (MalformedURLException e) {


### PR DESCRIPTION
Merging docker refactor into main branch.
Improvements:
- No longer need to build each time the tests are run (if no modifications are made)
- The project dependencies are downloaded in advance, instead of as part of the test-compile step
- Added compatibility with debugging (over VNC) for supported browsers (currently firefox and chrome)
- Generalized selenium hub container name so that it can be used across platforms without needing to know the unique name when it's built